### PR TITLE
Add Imperial Unit support and Settings Toggle

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -62,6 +62,7 @@
     <div id="map"></div>
     <div id="search-bar"></div>
     <div id="about-modal"></div>
+    <div id="settings-modal"></div>
 
     <script>
       window.cookieconsent.initialise({

--- a/src/components/EventBus.ts
+++ b/src/components/EventBus.ts
@@ -2,6 +2,7 @@ import { Activity } from "openskidata-format";
 import { MapMarker } from "../MapMarker";
 import { MapStyle } from "../MapStyle";
 import { InfoData } from "./InfoData";
+import { UnitSystem } from "./utils/UnitHelpers";
 
 export default interface EventBus {
   editMap(): void;
@@ -9,7 +10,10 @@ export default interface EventBus {
   closeSidebar(): void;
   openAboutInfo(): void;
   closeAboutInfo(): void;
+  openSettings(): void;
+  closeSettings(): void;
   setMapStyle(style: MapStyle): void;
+  setUnitSystem(unitSystem: UnitSystem): void;
   toggleActivity(activity: Activity): void;
   setMinimumElevation(elevation: number): void;
   setMinimumVertical(vertical: number): void;

--- a/src/components/FilterControl.tsx
+++ b/src/components/FilterControl.tsx
@@ -2,10 +2,11 @@ import * as mapboxgl from "mapbox-gl";
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 import MapFilters, { defaultMapFilters } from "../MapFilters";
+import controlWidth from "./controlWidth";
 import EventBus from "./EventBus";
 import { FilterForm } from "./FilterForm";
 import { Themed } from "./Themed";
-import controlWidth from "./controlWidth";
+import { UnitSystemManager } from "./UnitSystemManager";
 
 export class FilterControl implements mapboxgl.IControl {
   _container: HTMLDivElement;
@@ -51,11 +52,16 @@ export class FilterControl implements mapboxgl.IControl {
     }
     this._root.render(
       <Themed>
-        <FilterForm
-          eventBus={this._eventBus}
-          filters={this._filters}
-          width={controlWidth(this._map!)}
-          visibleSkiAreasCount={this._visibleSkiAreasCount}
+        <UnitSystemManager
+          render={(unitSystem) => (
+            <FilterForm
+              eventBus={this._eventBus}
+              filters={this._filters}
+              width={controlWidth(this._map!)}
+              visibleSkiAreasCount={this._visibleSkiAreasCount}
+              unitSystem={unitSystem}
+            />
+          )}
         />
       </Themed>
     );

--- a/src/components/FilterForm.tsx
+++ b/src/components/FilterForm.tsx
@@ -13,12 +13,14 @@ import MapFilters from "../MapFilters";
 import { DownhillCheckbox, NordicCheckbox } from "./Checkbox";
 import EventBus from "./EventBus";
 import { InfoHeader } from "./InfoHeader";
+import * as UnitHelpers from "./utils/UnitHelpers";
 
 export const FilterForm: React.FunctionComponent<{
   eventBus: EventBus;
   filters: MapFilters;
   width: number;
   visibleSkiAreasCount: number;
+  unitSystem: UnitHelpers.UnitSystem;
 }> = (props) => {
   const isDownhillEnabled = !props.filters.hiddenActivities.includes(
     Activity.Downhill
@@ -75,14 +77,22 @@ export const FilterForm: React.FunctionComponent<{
           </FormGroup>
         </div>
         <div style={formSectionStyle}>
-          <FormLabel component="legend">Minimum Elevation (m)</FormLabel>
+          <FormLabel component="legend">
+            Minimum Elevation (
+            {UnitHelpers.labelForLengthUnit(
+              UnitHelpers.closestEquivalent("meters", props.unitSystem)
+            )}
+            )
+          </FormLabel>
           <FormGroup style={sliderMargins}>
             <Slider
               defaultValue={initialMinElevationValue}
               min={0}
               max={5000}
               valueLabelDisplay="auto"
-              valueLabelFormat={(value) => value + " m"}
+              valueLabelFormat={(value) =>
+                UnitHelpers.heightText(value, props.unitSystem, true)
+              }
               onChange={(_, value) =>
                 props.eventBus.setMinimumElevation(value as number)
               }
@@ -90,14 +100,22 @@ export const FilterForm: React.FunctionComponent<{
           </FormGroup>
         </div>
         <div style={formSectionStyle}>
-          <FormLabel component="legend">Minimum Vertical (m)</FormLabel>
+          <FormLabel component="legend">
+            Minimum Vertical (
+            {UnitHelpers.labelForLengthUnit(
+              UnitHelpers.closestEquivalent("meters", props.unitSystem)
+            )}
+            )
+          </FormLabel>
           <FormGroup style={sliderMargins}>
             <Slider
               defaultValue={initialMinVerticalValue}
               min={0}
               max={2000}
               valueLabelDisplay="auto"
-              valueLabelFormat={(value) => value + " m"}
+              valueLabelFormat={(value) =>
+                UnitHelpers.heightText(value, props.unitSystem, true)
+              }
               onChange={(_, value) =>
                 props.eventBus.setMinimumVertical(value as number)
               }
@@ -105,14 +123,28 @@ export const FilterForm: React.FunctionComponent<{
           </FormGroup>
         </div>
         <div style={formSectionStyle}>
-          <FormLabel component="legend">Run Length (km)</FormLabel>
+          <FormLabel component="legend">
+            Run Length (
+            {UnitHelpers.labelForLengthUnit(
+              UnitHelpers.closestEquivalent("kilometers", props.unitSystem)
+            )}
+            )
+          </FormLabel>
           <FormGroup style={sliderMargins}>
             <Slider
               defaultValue={initialMinRunLengthValue}
               min={0}
               max={500}
               valueLabelDisplay="auto"
-              valueLabelFormat={(value) => value + " km"}
+              valueLabelFormat={(value) =>
+                UnitHelpers.distanceText({
+                  distanceInMeters: value * 1000,
+                  unitSystem: props.unitSystem,
+                  forceLongestUnit: true,
+                  withSpace: true,
+                  roundToNearestDecimal: true,
+                })
+              }
               onChange={(_, value) =>
                 props.eventBus.setMinimumRunLength(value as number)
               }

--- a/src/components/HeightProfile.tsx
+++ b/src/components/HeightProfile.tsx
@@ -25,6 +25,7 @@ import * as React from "react";
 import { Line } from "react-chartjs-2";
 import "whatwg-fetch";
 import { ElevationData } from "./ElevationData";
+import * as UnitHelpers from "./utils/UnitHelpers";
 
 Chart.register(LinearScale);
 Chart.register(CategoryScale);
@@ -41,6 +42,7 @@ interface HeightProfileProps extends HeightProfileHighlightProps {
   feature: GeoJSON.Feature<GeoJSON.LineString, RunProperties>;
   distance: number;
   elevationData: ElevationData;
+  unitSystem: UnitHelpers.UnitSystem;
 }
 
 export class HeightProfile extends React.Component<
@@ -121,7 +123,11 @@ export class HeightProfile extends React.Component<
     );
 
     const data: ChartData<"line", number[], string> = {
-      labels: chartLabels(elevations, elevationData.heightProfileResolution),
+      labels: chartLabels(
+        elevations,
+        elevationData.heightProfileResolution,
+        this.props.unitSystem
+      ),
       datasets: [
         {
           fill: true,
@@ -199,7 +205,10 @@ export class HeightProfile extends React.Component<
                   ) + elevationData.minElevation,
                 ticks: {
                   callback: (elevation: any) => {
-                    return elevation + "m";
+                    return UnitHelpers.heightText(
+                      elevation,
+                      this.props.unitSystem
+                    );
                   },
                 },
               },
@@ -214,11 +223,22 @@ export class HeightProfile extends React.Component<
   }
 }
 
-function chartLabels(elevations: number[], heightProfileResolution: number) {
+function chartLabels(
+  elevations: number[],
+  heightProfileResolution: number,
+  unitSystem: UnitHelpers.UnitSystem
+) {
   let distance = 0;
   const labels = [];
   for (let _ of elevations) {
-    labels.push((distance / 1000).toFixed(2) + " km");
+    labels.push(
+      UnitHelpers.distanceText({
+        distanceInMeters: distance,
+        unitSystem,
+        forceLongestUnit: true,
+        withSpace: true,
+      })
+    );
     distance += heightProfileResolution;
   }
   return labels;

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -13,6 +13,7 @@ import { SkiAreaInfo } from "./SkiAreaInfo";
 import { SkiLiftInfo } from "./SkiLiftInfo";
 import { SkiRunInfo } from "./SkiRunInfo";
 import { updatePageMetadata } from "./utils/PageMetadata";
+import * as UnitHelpers from "./utils/UnitHelpers";
 
 type MapFeature = RunFeature | LiftFeature | SkiAreaFeature;
 
@@ -21,6 +22,7 @@ export const Info: React.FunctionComponent<{
   width: number;
   eventBus: EventBus;
   chartHighlightPosition: mapboxgl.LngLat | null;
+  unitSystem: UnitHelpers.UnitSystem;
   onLoadFeature: (feature: MapFeature) => void;
   onHoverChartPosition: (position: mapboxgl.LngLat | null) => void;
 }> = (props) => {
@@ -50,6 +52,7 @@ export const Info: React.FunctionComponent<{
         <SkiLiftInfo
           feature={feature as LiftFeature}
           eventBus={props.eventBus}
+          unitSystem={props.unitSystem}
         />
       )}
       {feature && feature.properties.type == FeatureType.Run && (
@@ -58,12 +61,14 @@ export const Info: React.FunctionComponent<{
           chartHighlightPosition={props.chartHighlightPosition}
           onHoverChartPosition={props.onHoverChartPosition}
           eventBus={props.eventBus}
+          unitSystem={props.unitSystem}
         />
       )}
       {feature && feature.properties.type == FeatureType.SkiArea && (
         <SkiAreaInfo
           feature={feature as SkiAreaFeature}
           eventBus={props.eventBus}
+          unitSystem={props.unitSystem}
         />
       )}
     </Card>

--- a/src/components/InfoControl.tsx
+++ b/src/components/InfoControl.tsx
@@ -7,6 +7,7 @@ import { Info } from "./Info";
 import { InfoData } from "./InfoData";
 import { panToZoomLevel } from "./SkiAreaInfo";
 import { Themed } from "./Themed";
+import { UnitSystemManager } from "./UnitSystemManager";
 import controlWidth from "./controlWidth";
 import { getFirstPoint } from "./utils/GeoJSON";
 
@@ -61,22 +62,29 @@ export class InfoControl implements mapboxgl.IControl, ChartHighlighter {
     }
     this._root.render(
       <Themed>
-        <Info
-          id={this._id}
-          eventBus={this._eventBus}
-          width={controlWidth(map)}
-          chartHighlightPosition={this._chartHighlightPosition}
-          onLoadFeature={(feature) => {
-            if (this._panToPositionAfterLoad) {
-              const point = getFirstPoint(feature.geometry);
-              this._map?.flyTo({
-                center: [point[0], point[1]],
-                zoom: panToZoomLevel,
-              });
-            }
-          }}
-          onHoverChartPosition={this._highlightManager!.hoveredChartPosition}
-        />
+        <UnitSystemManager
+          render={(unitSystem) => (
+            <Info
+              id={this._id}
+              eventBus={this._eventBus}
+              width={controlWidth(map)}
+              chartHighlightPosition={this._chartHighlightPosition}
+              unitSystem={unitSystem}
+              onLoadFeature={(feature) => {
+                if (this._panToPositionAfterLoad) {
+                  const point = getFirstPoint(feature.geometry);
+                  this._map?.flyTo({
+                    center: [point[0], point[1]],
+                    zoom: panToZoomLevel,
+                  });
+                }
+              }}
+              onHoverChartPosition={
+                this._highlightManager!.hoveredChartPosition
+              }
+            />
+          )}
+        ></UnitSystemManager>
       </Themed>
     );
   }

--- a/src/components/InfoControl.tsx
+++ b/src/components/InfoControl.tsx
@@ -84,7 +84,7 @@ export class InfoControl implements mapboxgl.IControl, ChartHighlighter {
               }
             />
           )}
-        ></UnitSystemManager>
+        />
       </Themed>
     );
   }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -57,7 +57,7 @@ export class Map {
 
     addUnitSystemChangeListener_NonReactive({
       onUnitSystemChange: (unitSystem) => {
-        this.updateCountourLabelUnits(unitSystem);
+        this.updateContourLabelUnits(unitSystem);
         this.updateScaleControlUnits(unitSystem);
       },
       triggerWhenInitialized: true,
@@ -89,7 +89,7 @@ export class Map {
     });
   }
 
-  private updateCountourLabelUnits(unitSystem: UnitSystem) {
+  private updateContourLabelUnits(unitSystem: UnitSystem) {
     this.waitForMapLoaded(() => {
       const loadedStyle = { ...this.map.getStyle() };
 
@@ -163,7 +163,7 @@ export class Map {
   setStyle = (style: MapStyle) => {
     this.map.setStyle(style);
 
-    this.updateCountourLabelUnits(getUnitSystem_NonReactive());
+    this.updateContourLabelUnits(getUnitSystem_NonReactive());
   };
 
   private setFiltersUnthrottled = (filters: MapFilters) => {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,61 @@
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from "@mui/material";
+import * as React from "react";
+import EventBus from "./EventBus";
+import { InfoHeader } from "./InfoHeader";
+import { UnitSystem } from "./utils/UnitHelpers";
+
+interface Props {
+  unitSystem: UnitSystem;
+  eventBus: EventBus;
+}
+
+export default class Settings extends React.Component<Props> {
+  render() {
+    return (
+      <>
+        <InfoHeader onClose={() => this.props.eventBus.closeSettings()}>
+          <Typography variant="h5" id="modal-title">
+            Settings
+          </Typography>
+        </InfoHeader>
+
+        <div style={{ width: 500, padding: "8px 8px" }}>
+          <FormControl>
+            <FormLabel>
+              {" "}
+              <Typography fontSize="1.15rem" color="WindowText">
+                Unit Style{" "}
+              </Typography>
+            </FormLabel>
+            <RadioGroup
+              value={this.props.unitSystem}
+              onChange={(e) => {
+                const newUnitSystem = (e.target as HTMLInputElement)
+                  .value as UnitSystem;
+                this.props.eventBus.setUnitSystem(newUnitSystem);
+              }}
+            >
+              <FormControlLabel
+                value="metric"
+                control={<Radio />}
+                label="Metric"
+              />
+              <FormControlLabel
+                value="imperial"
+                control={<Radio />}
+                label="Imperial"
+              />
+            </RadioGroup>
+          </FormControl>
+        </div>
+      </>
+    );
+  }
+}

--- a/src/components/SettingsEvent.ts
+++ b/src/components/SettingsEvent.ts
@@ -1,0 +1,13 @@
+type SettingsEventInit = {
+  settingsProperty: string;
+};
+
+export class SettingsEvent extends CustomEvent<SettingsEventInit> {
+  public static EVENT_TYPE = "settings_update";
+
+  public static UNIT_SYSTEM_SETTINGS_PROPERTY = "unitSystem";
+
+  constructor(eventInitDict: SettingsEventInit) {
+    super(SettingsEvent.EVENT_TYPE, { detail: eventInitDict });
+  }
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,25 @@
+import { Dialog } from "@mui/material";
+import { Box } from "@mui/system";
+import * as React from "react";
+import EventBus from "./EventBus";
+import Settings from "./Settings";
+import { UnitSystem } from "./utils/UnitHelpers";
+
+export const SettingsModal: React.FunctionComponent<{
+  open: boolean;
+  unitSystem: UnitSystem;
+  eventBus: EventBus;
+}> = (props) => {
+  return (
+    <Dialog
+      open={props.open}
+      onClose={() => {
+        props.eventBus.closeSettings();
+      }}
+    >
+      <Box sx={{ p: 4 }}>
+        <Settings eventBus={props.eventBus} unitSystem={props.unitSystem} />
+      </Box>
+    </Dialog>
+  );
+};

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import EditIcon from "@mui/icons-material/Edit";
 import InfoIcon from "@mui/icons-material/Info";
 import SatelliteIcon from "@mui/icons-material/Satellite";
 import SettingsIcon from "@mui/icons-material/Settings";
-
 import TerrainIcon from "@mui/icons-material/Terrain";
 import {
   Divider,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,3 +1,9 @@
+import EditIcon from "@mui/icons-material/Edit";
+import InfoIcon from "@mui/icons-material/Info";
+import SatelliteIcon from "@mui/icons-material/Satellite";
+import SettingsIcon from "@mui/icons-material/Settings";
+
+import TerrainIcon from "@mui/icons-material/Terrain";
 import {
   Divider,
   Drawer,
@@ -6,10 +12,6 @@ import {
   ListItemIcon,
   ListItemText,
 } from "@mui/material";
-import EditIcon from "@mui/icons-material/Edit";
-import InfoIcon from "@mui/icons-material/Info";
-import SatelliteIcon from "@mui/icons-material/Satellite";
-import TerrainIcon from "@mui/icons-material/Terrain";
 import * as React from "react";
 import { MapStyle } from "../MapStyle";
 import EventBus from "./EventBus";
@@ -62,6 +64,16 @@ export default class Sidebar extends React.Component<Props, {}> {
             </List>
             <Divider />
             <List>
+              <ListItem
+                button
+                key={"settings"}
+                onClick={this.props.eventBus.openSettings}
+              >
+                <ListItemIcon>
+                  <SettingsIcon />
+                </ListItemIcon>
+                <ListItemText primary={"Settings"} />
+              </ListItem>
               <ListItem
                 button
                 key={"edit"}

--- a/src/components/SkiLiftInfo.tsx
+++ b/src/components/SkiLiftInfo.tsx
@@ -9,9 +9,12 @@ import { InfoHeader } from "./InfoHeader";
 import { SourceSummary } from "./SourceSummary";
 import { StatusIcon } from "./StatusIcon";
 import getInclinedLengthInMeters from "./utils/InclinedLength";
+import * as UnitHelpers from "./utils/UnitHelpers";
+
 export const SkiLiftInfo: React.FunctionComponent<{
   eventBus: EventBus;
   feature: LiftFeature;
+  unitSystem: UnitHelpers.UnitSystem;
 }> = (props) => {
   const properties = props.feature.properties;
   const geometry = props.feature.geometry;
@@ -59,16 +62,32 @@ export const SkiLiftInfo: React.FunctionComponent<{
         {
           <div className={"distance-and-elevation-info"}>
             {distance && (
-              <Typography>Distance: {Math.round(distance)}m</Typography>
+              <>
+                <Typography>
+                  Distance:{" "}
+                  {UnitHelpers.distanceText({
+                    distanceInMeters: distance,
+                    unitSystem: props.unitSystem,
+                  })}
+                </Typography>
+              </>
             )}
             {ascentAndDescent && ascentAndDescent.ascent > 1 && (
               <Typography>
-                Ascent: {Math.round(ascentAndDescent.ascent)}m
+                Ascent:{" "}
+                {UnitHelpers.heightText(
+                  ascentAndDescent.ascent,
+                  props.unitSystem
+                )}
               </Typography>
             )}
             {ascentAndDescent && ascentAndDescent.descent > 1 && (
               <Typography>
-                Descent: {Math.round(ascentAndDescent.descent)}m
+                Descent:{" "}
+                {UnitHelpers.heightText(
+                  ascentAndDescent.descent,
+                  props.unitSystem
+                )}
               </Typography>
             )}
             {speed && <Typography>Speed: {speed.toFixed(1)} m/s</Typography>}

--- a/src/components/SkiRunInfo.tsx
+++ b/src/components/SkiRunInfo.tsx
@@ -28,10 +28,12 @@ import { InfoHeader } from "./InfoHeader";
 import { SourceSummary } from "./SourceSummary";
 import getInclinedLengthInMeters from "./utils/InclinedLength";
 import { getRunTitleAndSubtitle } from "./utils/PageMetadata";
+import * as UnitHelpers from "./utils/UnitHelpers";
 
 interface Props extends HeightProfileHighlightProps {
   feature: RunFeature;
   eventBus: EventBus;
+  unitSystem: UnitHelpers.UnitSystem;
 }
 
 export const SkiRunInfo: React.FunctionComponent<Props> = (props) => {
@@ -126,13 +128,25 @@ export const SkiRunInfo: React.FunctionComponent<Props> = (props) => {
         ) : null}
         <Typography className={"distance-and-elevation-info"}>
           {inclinedDistance ? (
-            <span>Distance: {Math.round(inclinedDistance)}m</span>
+            <span>
+              Distance:{" "}
+              {UnitHelpers.distanceText({
+                distanceInMeters: inclinedDistance,
+                unitSystem: props.unitSystem,
+              })}
+            </span>
           ) : null}
           {elevationData && elevationData.ascent > 1 ? (
-            <span>Ascent: {Math.round(elevationData.ascent)}m</span>
+            <span>
+              Ascent:{" "}
+              {UnitHelpers.heightText(elevationData.ascent, props.unitSystem)}
+            </span>
           ) : null}
           {elevationData && elevationData.descent > 1 ? (
-            <span>Descent: {Math.round(elevationData.descent)}m</span>
+            <span>
+              Descent:{" "}
+              {UnitHelpers.heightText(elevationData.descent, props.unitSystem)}
+            </span>
           ) : null}
         </Typography>
         {slopeInfo && (
@@ -157,6 +171,7 @@ export const SkiRunInfo: React.FunctionComponent<Props> = (props) => {
             elevationData={elevationData}
             chartHighlightPosition={props.chartHighlightPosition}
             onHoverChartPosition={props.onHoverChartPosition}
+            unitSystem={props.unitSystem}
           />
         )}
         {<SourceSummary sources={properties.sources} />}

--- a/src/components/State.ts
+++ b/src/components/State.ts
@@ -14,7 +14,7 @@ export default interface State {
   mapFilters: MapFilters;
   info: InfoData | null;
   markers: MapMarker[];
-  unitSystem: "metric" | "imperial";
+  unitSystem: UnitHelpers.UnitSystem;
 }
 
 export interface StateChanges {
@@ -27,7 +27,7 @@ export interface StateChanges {
   info?: InfoData | null;
   markers?: MapMarker[];
   latestMarker?: MapMarker;
-  unitSystem?: "metric" | "imperial";
+  unitSystem?: UnitHelpers.UnitSystem;
 }
 
 export function getInitialState(): State {
@@ -40,6 +40,6 @@ export function getInitialState(): State {
     mapFilters: defaultMapFilters,
     info: null,
     markers: [],
-    unitSystem: UnitHelpers.unitSystemFromString(getUnitSystem_NonReactive()),
+    unitSystem: getUnitSystem_NonReactive(),
   };
 }

--- a/src/components/State.ts
+++ b/src/components/State.ts
@@ -2,36 +2,44 @@ import MapFilters, { defaultMapFilters } from "../MapFilters";
 import { MapMarker } from "../MapMarker";
 import { MapStyle } from "../MapStyle";
 import { InfoData } from "./InfoData";
+import { getUnitSystem_NonReactive } from "./UnitSystemManager";
+import * as UnitHelpers from "./utils/UnitHelpers";
 
 export default interface State {
   sidebarOpen: boolean;
   aboutInfoOpen: boolean;
+  settingsOpen: boolean;
   mapFiltersOpen: boolean;
   mapStyle: MapStyle;
   mapFilters: MapFilters;
   info: InfoData | null;
   markers: MapMarker[];
+  unitSystem: "metric" | "imperial";
 }
 
 export interface StateChanges {
   sidebarOpen?: boolean;
   aboutInfoOpen?: boolean;
+  settingsOpen?: boolean;
   mapFiltersOpen?: boolean;
   mapStyle?: MapStyle;
   mapFilters?: MapFilters;
   info?: InfoData | null;
   markers?: MapMarker[];
   latestMarker?: MapMarker;
+  unitSystem?: "metric" | "imperial";
 }
 
 export function getInitialState(): State {
   return {
     sidebarOpen: false,
     aboutInfoOpen: false,
+    settingsOpen: false,
     mapFiltersOpen: false,
     mapStyle: MapStyle.Terrain,
     mapFilters: defaultMapFilters,
     info: null,
     markers: [],
+    unitSystem: UnitHelpers.unitSystemFromString(getUnitSystem_NonReactive()),
   };
 }

--- a/src/components/StateStore.ts
+++ b/src/components/StateStore.ts
@@ -52,9 +52,9 @@ export default class StateStore implements EventBus {
     this.update({ mapStyle: style });
   };
 
-  setUnitSystem(unitSystem: UnitSystem): void {
+  setUnitSystem = (unitSystem: UnitSystem) => {
     this.update({ unitSystem });
-  }
+  };
 
   urlUpdate = (state: URLState) => {
     this.update({

--- a/src/components/StateStore.ts
+++ b/src/components/StateStore.ts
@@ -5,6 +5,7 @@ import EventBus from "./EventBus";
 import { InfoData } from "./InfoData";
 import State, { StateChanges } from "./State";
 import { URLState } from "./URLHistory";
+import { UnitSystem } from "./utils/UnitHelpers";
 
 export default class StateStore implements EventBus {
   _state: State;
@@ -39,9 +40,21 @@ export default class StateStore implements EventBus {
     this.update({ aboutInfoOpen: false });
   };
 
+  openSettings = () => {
+    this.update({ settingsOpen: true });
+  };
+
+  closeSettings = () => {
+    this.update({ settingsOpen: false });
+  };
+
   setMapStyle = (style: MapStyle) => {
     this.update({ mapStyle: style });
   };
+
+  setUnitSystem(unitSystem: UnitSystem): void {
+    this.update({ unitSystem });
+  }
 
   urlUpdate = (state: URLState) => {
     this.update({

--- a/src/components/UnitSystemManager.tsx
+++ b/src/components/UnitSystemManager.tsx
@@ -7,15 +7,13 @@ export const UnitSystemManager: React.FunctionComponent<{
   render: (unitSystem: UnitSystem) => React.ReactNode;
 }> = (props) => {
   const [unitSystem, setUnitSystem] = React.useState<UnitSystem>(
-    unitSystemFromString(getUnitSystem_NonReactive())
+    getUnitSystem_NonReactive()
   );
 
   React.useEffect(() => {
     const handleStorageChange = (event: StorageEvent) => {
-      console.log(event);
-
       if (event.key === UNIT_SYSTEM_SETTING_KEY) {
-        setUnitSystem(unitSystemFromString(getUnitSystem_NonReactive()));
+        setUnitSystem(getUnitSystem_NonReactive());
       }
     };
 
@@ -53,8 +51,6 @@ export function addUnitSystemChangeListener_NonReactive({
   triggerWhenInitialized: boolean;
 }) {
   const handleStorageChange = (event: StorageEvent) => {
-    console.log(event);
-
     if (event.key === UNIT_SYSTEM_SETTING_KEY) {
       onUnitSystemChange(getUnitSystem_NonReactive());
     }

--- a/src/components/UnitSystemManager.tsx
+++ b/src/components/UnitSystemManager.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
+import { SettingsEvent } from "./SettingsEvent";
 import { UnitSystem, unitSystemFromString } from "./utils/UnitHelpers";
 
-const UNIT_SYSTEM_SETTING_KEY = "setting.unitSystem";
+const UNIT_SYSTEM_SETTING_LOCAL_STORAGE_KEY = "setting.unitSystem";
 
 export const UnitSystemManager: React.FunctionComponent<{
   render: (unitSystem: UnitSystem) => React.ReactNode;
@@ -11,16 +12,22 @@ export const UnitSystemManager: React.FunctionComponent<{
   );
 
   React.useEffect(() => {
-    const handleStorageChange = (event: StorageEvent) => {
-      if (event.key === UNIT_SYSTEM_SETTING_KEY) {
+    const handleSettingsChange = (event: Event) => {
+      if (
+        (event as SettingsEvent).detail.settingsProperty ===
+        SettingsEvent.UNIT_SYSTEM_SETTINGS_PROPERTY
+      ) {
         setUnitSystem(getUnitSystem_NonReactive());
       }
     };
 
-    window.addEventListener("storage", handleStorageChange);
+    window.addEventListener(SettingsEvent.EVENT_TYPE, handleSettingsChange);
 
     return () => {
-      window.removeEventListener("storage", handleStorageChange);
+      window.removeEventListener(
+        SettingsEvent.EVENT_TYPE,
+        handleSettingsChange
+      );
     };
   }, []);
 
@@ -28,19 +35,19 @@ export const UnitSystemManager: React.FunctionComponent<{
 };
 
 export function setUnitSystem(unitSystem: UnitSystem) {
-  const storageEvent = new StorageEvent("storage", {
-    oldValue: getUnitSystem_NonReactive(),
-    newValue: unitSystem,
-    key: UNIT_SYSTEM_SETTING_KEY,
+  const event = new SettingsEvent({
+    settingsProperty: SettingsEvent.UNIT_SYSTEM_SETTINGS_PROPERTY,
   });
 
-  localStorage.setItem(UNIT_SYSTEM_SETTING_KEY, unitSystem);
+  localStorage.setItem(UNIT_SYSTEM_SETTING_LOCAL_STORAGE_KEY, unitSystem);
 
-  window.dispatchEvent(storageEvent);
+  window.dispatchEvent(event);
 }
 
 export function getUnitSystem_NonReactive(): UnitSystem {
-  return unitSystemFromString(localStorage.getItem(UNIT_SYSTEM_SETTING_KEY));
+  return unitSystemFromString(
+    localStorage.getItem(UNIT_SYSTEM_SETTING_LOCAL_STORAGE_KEY)
+  );
 }
 
 export function addUnitSystemChangeListener_NonReactive({
@@ -50,13 +57,16 @@ export function addUnitSystemChangeListener_NonReactive({
   onUnitSystemChange: (unitSystem: UnitSystem) => void;
   triggerWhenInitialized: boolean;
 }) {
-  const handleStorageChange = (event: StorageEvent) => {
-    if (event.key === UNIT_SYSTEM_SETTING_KEY) {
+  const handleSettingsChange = (event: Event) => {
+    if (
+      (event as SettingsEvent).detail.settingsProperty ===
+      SettingsEvent.UNIT_SYSTEM_SETTINGS_PROPERTY
+    ) {
       onUnitSystemChange(getUnitSystem_NonReactive());
     }
   };
 
-  window.addEventListener("storage", handleStorageChange);
+  window.addEventListener(SettingsEvent.EVENT_TYPE, handleSettingsChange);
   if (triggerWhenInitialized) {
     onUnitSystemChange(getUnitSystem_NonReactive());
   }

--- a/src/components/UnitSystemManager.tsx
+++ b/src/components/UnitSystemManager.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { UnitSystem, unitSystemFromString } from "./utils/UnitHelpers";
+
+const UNIT_SYSTEM_SETTING_KEY = "setting.unitSystem";
+
+export const UnitSystemManager: React.FunctionComponent<{
+  render: (unitSystem: UnitSystem) => React.ReactNode;
+}> = (props) => {
+  const [unitSystem, setUnitSystem] = React.useState<UnitSystem>(
+    unitSystemFromString(getUnitSystem_NonReactive())
+  );
+
+  React.useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      console.log(event);
+
+      if (event.key === UNIT_SYSTEM_SETTING_KEY) {
+        setUnitSystem(unitSystemFromString(getUnitSystem_NonReactive()));
+      }
+    };
+
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, []);
+
+  return props.render(unitSystem);
+};
+
+export function setUnitSystem(unitSystem: UnitSystem) {
+  const storageEvent = new StorageEvent("storage", {
+    oldValue: getUnitSystem_NonReactive(),
+    newValue: unitSystem,
+    key: UNIT_SYSTEM_SETTING_KEY,
+  });
+
+  localStorage.setItem(UNIT_SYSTEM_SETTING_KEY, unitSystem);
+
+  window.dispatchEvent(storageEvent);
+}
+
+export function getUnitSystem_NonReactive(): UnitSystem {
+  return unitSystemFromString(localStorage.getItem(UNIT_SYSTEM_SETTING_KEY));
+}
+
+export function addUnitSystemChangeListener_NonReactive({
+  onUnitSystemChange,
+  triggerWhenInitialized,
+}: {
+  onUnitSystemChange: (unitSystem: UnitSystem) => void;
+  triggerWhenInitialized: boolean;
+}) {
+  const handleStorageChange = (event: StorageEvent) => {
+    console.log(event);
+
+    if (event.key === UNIT_SYSTEM_SETTING_KEY) {
+      onUnitSystemChange(getUnitSystem_NonReactive());
+    }
+  };
+
+  window.addEventListener("storage", handleStorageChange);
+  if (triggerWhenInitialized) {
+    onUnitSystemChange(getUnitSystem_NonReactive());
+  }
+}

--- a/src/components/utils/UnitHelpers.ts
+++ b/src/components/utils/UnitHelpers.ts
@@ -1,0 +1,161 @@
+export type UnitSystem = "metric" | "imperial";
+
+type MetricLengthUnit = "meters" | "kilometers";
+
+type LengthUnit = MetricLengthUnit | "feet" | "miles";
+type LengthWithUnit = {
+  length: number;
+  lengthUnit: LengthUnit;
+};
+
+export function unitSystemFromString(unitSystem: string | null): UnitSystem {
+  switch (unitSystem) {
+    case "imperial":
+    case "metric":
+      return unitSystem;
+    default:
+      return "metric";
+  }
+}
+
+export function closestEquivalent(
+  unit: MetricLengthUnit,
+  unitSystem: UnitSystem
+): LengthUnit {
+  switch (unitSystem) {
+    case "metric":
+      switch (unit) {
+        case "meters":
+          return "meters";
+        case "kilometers":
+          return "kilometers";
+      }
+    case "imperial":
+      switch (unit) {
+        case "meters":
+          return "feet";
+        case "kilometers":
+          return "miles";
+      }
+  }
+}
+
+export function labelForLengthUnit(unit: LengthUnit) {
+  switch (unit) {
+    case "feet":
+      return `ft`;
+    case "meters":
+      return `m`;
+    case "kilometers":
+      return `km`;
+    case "miles":
+      return `mi`;
+  }
+}
+
+function formattedLengthString(
+  lengthWithUnit: LengthWithUnit,
+  withSpace: boolean
+) {
+  const unit = lengthWithUnit.lengthUnit;
+  const valuePrefix = `${lengthWithUnit.length}${withSpace ? " " : ""}`;
+
+  return `${valuePrefix}${labelForLengthUnit(unit)}`;
+}
+
+function convertDistance(
+  lengthInMeters: number,
+  unit: LengthUnit,
+  roundToNearestDecimal = false
+): LengthWithUnit {
+  let lengthInUnit;
+
+  const decimals = roundToNearestDecimal ? 0 : 2;
+  const decimalFactor = 10 ** decimals;
+
+  switch (unit) {
+    case "feet":
+      lengthInUnit = Math.round(lengthInMeters * 3.28084);
+      break;
+    case "meters":
+      lengthInUnit = Math.round(lengthInMeters * 1);
+      break;
+    case "kilometers":
+      lengthInUnit =
+        Math.round(lengthInMeters * 0.001 * decimalFactor) / decimalFactor;
+      break;
+    case "miles":
+      lengthInUnit =
+        Math.round(lengthInMeters * 0.000621371 * decimalFactor) /
+        decimalFactor;
+      break;
+  }
+
+  return { length: lengthInUnit, lengthUnit: unit };
+}
+
+export function heightText(
+  heightInMeters: number,
+  unitSystem: UnitSystem,
+  withSpace = false
+) {
+  switch (unitSystem) {
+    case "metric":
+      return formattedLengthString(
+        convertDistance(heightInMeters, "meters"),
+        withSpace
+      );
+    case "imperial":
+      return formattedLengthString(
+        convertDistance(heightInMeters, "feet"),
+        withSpace
+      );
+  }
+}
+
+export function distanceText({
+  distanceInMeters,
+  unitSystem,
+  forceLongestUnit = false,
+  roundToNearestDecimal = false,
+  withSpace = false,
+}: {
+  distanceInMeters: number;
+  unitSystem: UnitSystem;
+  forceLongestUnit?: boolean;
+  roundToNearestDecimal?: boolean;
+  withSpace?: boolean;
+}) {
+  switch (unitSystem) {
+    case "metric":
+      const distanceInKilometers = convertDistance(
+        distanceInMeters,
+        "kilometers",
+        roundToNearestDecimal
+      );
+
+      if (forceLongestUnit || distanceInKilometers.length > 1) {
+        return formattedLengthString(distanceInKilometers, withSpace);
+      }
+
+      return formattedLengthString(
+        convertDistance(distanceInMeters, "meters"),
+        withSpace
+      );
+    case "imperial":
+      const distanceInMiles = convertDistance(
+        distanceInMeters,
+        "miles",
+        roundToNearestDecimal
+      );
+
+      if (forceLongestUnit || distanceInMiles.length >= 0.1) {
+        return formattedLengthString(distanceInMiles, withSpace);
+      }
+
+      return formattedLengthString(
+        convertDistance(distanceInMeters, "feet"),
+        withSpace
+      );
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,10 +6,12 @@ import "./assets/robots.txt";
 import { AboutModal } from "./components/AboutModal";
 import { editMap } from "./components/ExternalURLOpener";
 import { Map } from "./components/Map";
+import { SettingsModal } from "./components/SettingsModal";
 import Sidebar from "./components/Sidebar";
 import State, { getInitialState, StateChanges } from "./components/State";
 import StateStore from "./components/StateStore";
 import { Themed } from "./components/Themed";
+import { setUnitSystem } from "./components/UnitSystemManager";
 import { getURLState, updateURL } from "./components/URLHistory";
 import { updatePageMetadata } from "./components/utils/PageMetadata";
 import * as Config from "./Config";
@@ -21,6 +23,9 @@ function initialize() {
   const sidebarRoot = ReactDOM.createRoot(document.getElementById("sidebar")!);
   const aboutRoot = ReactDOM.createRoot(
     document.getElementById("about-modal")!
+  );
+  const settingsRoot = ReactDOM.createRoot(
+    document.getElementById("settings-modal")!
   );
 
   const store = new StateStore(getInitialState(), update);
@@ -92,6 +97,21 @@ function initialize() {
       );
     }
 
+    if (
+      changes.settingsOpen !== undefined ||
+      changes.unitSystem !== undefined
+    ) {
+      settingsRoot.render(
+        <Themed>
+          <SettingsModal
+            eventBus={store}
+            open={state.settingsOpen}
+            unitSystem={state.unitSystem}
+          />
+        </Themed>
+      );
+    }
+
     if (changes.mapFiltersOpen !== undefined) {
       map.setFiltersVisible(changes.mapFiltersOpen);
     }
@@ -114,6 +134,10 @@ function initialize() {
     if (changes.latestMarker !== undefined) {
       const coordinates = changes.latestMarker.coordinates;
       map.flyTo([coordinates[0], coordinates[1]]);
+    }
+
+    if (changes.unitSystem !== undefined) {
+      setUnitSystem(changes.unitSystem);
     }
   }
 


### PR DESCRIPTION
This change adds imperial unit support to open ski map. Some screenshots:

## Resort Features 
<img width="409" alt="image" src="https://github.com/user-attachments/assets/428e4379-ccc2-466d-bee6-7da87f2e2ac1" />

<img width="416" alt="image" src="https://github.com/user-attachments/assets/5b759cd0-90e4-4c74-b98b-db28f86abddb" />

<img width="415" alt="image" src="https://github.com/user-attachments/assets/d864d5b6-6ccd-4cc3-9c40-15888fcd8b5c" />

## Map Features
<img width="280" alt="image" src="https://github.com/user-attachments/assets/219e3750-ba91-42d1-ab28-2fca6702995f" />

<img width="130" alt="image" src="https://github.com/user-attachments/assets/8f0c2b2b-16cf-4e70-a006-ec9206226f64" />


## Settings
<img width="235" alt="image" src="https://github.com/user-attachments/assets/9965d15c-6f42-4cf8-b753-5afe69a3fd90" />

<img width="612" alt="image" src="https://github.com/user-attachments/assets/e2d3258f-18fb-4bb6-a850-9a5d7422fb2b" />

## Reactivity
![Kapture 2025-01-23 at 12 52 32](https://github.com/user-attachments/assets/98821779-2ec8-4dfb-9ff1-135755e60ed8)
